### PR TITLE
Fixed safari tab bug

### DIFF
--- a/examples/simple/src/routes/stateless/grouping/static/index.js
+++ b/examples/simple/src/routes/stateless/grouping/static/index.js
@@ -79,6 +79,7 @@ const StatlessGroupingStatic = ({
         value={value_1}
         visible={visible_1}
       />
+      <input type="text" />
     </div>
     <div style={{zIndex:'80', marginTop: '20px', position:'relative'}}>
       Unlike the option above, this example displays how to using Groupings

--- a/examples/simple/src/routes/stateless/no-groups/static/index.js
+++ b/examples/simple/src/routes/stateless/no-groups/static/index.js
@@ -69,8 +69,10 @@ const StatlessNoGroupStatic = ({
             value={value_1}
             visible={visible_1}
           />
+          <input type="text" tabIndex={2} />
+          <input type="text" tabIndex={3} />
         </div>
-        <button type="submit" style={{marginLeft: '20px'}}>Submit Form</button>
+        <button type="submit" tabIndex={4} style={{marginLeft: '20px'}}>Submit Form</button>
       </form>
     </div>
 
@@ -112,7 +114,7 @@ const StatlessNoGroupStatic = ({
           options={defaultOptions}
           placeholder={'Stateless Without Groups'}
           sortable={true}
-          tabIndex={2}
+          tabIndex={5}
           typedValue={typedValue_2}
           value={value_2}
           visible={visible_2}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ddm-selecty",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A select component patterned after selectize",
   "main": "./dist/ddm.selecty.js",
   "scripts": {

--- a/src/input/index.js
+++ b/src/input/index.js
@@ -13,6 +13,7 @@ const InputElement = ({
   onKeyDown,
   onKeyUp,
   tabIndex,
+  inputRef,
 }) => (
   <input
     autoComplete="off"
@@ -28,6 +29,8 @@ const InputElement = ({
     onKeyDown={e => onKeyDown(e)}
     onKeyUp={e => onKeyUp(e)}
     tabIndex={tabIndex}
+    onFocus={e => e.target.select()}
+    ref={inputRef}
   />
 );
 
@@ -48,6 +51,7 @@ InputElement.propTypes = {
   ]).isRequired,
   onKeyUp: PropTypes.func.isRequired,
   tabIndex: PropTypes.number,
+  inputRef: PropTypes.any,
 };
 
 export default CSSModules(InputElement, styles);

--- a/src/simple/stateless/index.js
+++ b/src/simple/stateless/index.js
@@ -85,6 +85,7 @@ export const SimpleSelectyStateless = ({
         onKeyDown={e => keyEvents(e, 'down', filterable, lazyLoading, Options, sortable, typedValue, updateFunctions)}
         onKeyUp={e => keyEvents(e, 'up', filterable, lazyLoading, Options, sortable, typedValue, updateFunctions)}
         onChange={onChange}
+        tabIndex={tabIndex}
       />
       <Suggestions
         autoHighlight={autoHighlight}

--- a/src/simple/stateless/index.js
+++ b/src/simple/stateless/index.js
@@ -73,8 +73,24 @@ export const SimpleSelectyStateless = ({
     Options.sorted = sortOptions(Options.filtered, optLabel, sortable);
     Options.grouped = createGrouping(Options.sorted, optionGroups);
   }
+
+  var inputRef = null;
+
+  const setInputRef = (input) => {
+    inputRef = input;
+  };
+
+  const focusWrapper = () => {
+    if (inputRef) {
+      inputRef.select();
+    }
+    if (onFocus) {
+      onFocus();
+    }
+  };
+
   return (
-    <div onBlur={onBlur} onFocus={onFocus} tabIndex={tabIndex} styleName="wrapper">
+    <div onBlur={onBlur} onFocus={focusWrapper} tabIndex={tabIndex} styleName="wrapper">
       <InputElement
         autofocus={autofocus}
         disabled={disabled}
@@ -85,6 +101,7 @@ export const SimpleSelectyStateless = ({
         onKeyDown={e => keyEvents(e, 'down', filterable, lazyLoading, Options, sortable, typedValue, updateFunctions)}
         onKeyUp={e => keyEvents(e, 'up', filterable, lazyLoading, Options, sortable, typedValue, updateFunctions)}
         onChange={onChange}
+        inputRef={input => setInputRef(input)}
         tabIndex={tabIndex}
       />
       <Suggestions

--- a/src/simple/stateless/utils/events.js
+++ b/src/simple/stateless/utils/events.js
@@ -31,7 +31,6 @@ export default (key, index, first, last, next, prev, options, optType, typedValu
         update.onFiltered(filtered);
       }
       update.onChange(text);
-      document.activeElement.blur();
       break;
     }
     case 'esc': {


### PR DESCRIPTION
Tab is fixed, but we still have a limitation on Mac (Safari and FF for Mac).
Taking into account that Apple decided that we don't need to be able to select something else except text field, we are not able to focus the user on the Submit button. Anyway, there is a simple way how to solve it. The user should just turn on this feature on his browser. It's weird, but it's true. Here is proof link http://stackoverflow.com/a/2862362

@jmacd3 @QuietOmen 
